### PR TITLE
Config parser

### DIFF
--- a/Client.hpp
+++ b/Client.hpp
@@ -38,6 +38,9 @@ class Client {
 		unsigned long	last_request_time;
 		unsigned long	last_response_time;
 
+		static unsigned long	recv_time_out;
+		static unsigned long	send_time_out;
+
 		std::string				read_buff;
 		std::queue<Request>		requests;
 		std::queue<Response>	responses;

--- a/Client.hpp
+++ b/Client.hpp
@@ -38,9 +38,6 @@ class Client {
 		unsigned long	last_request_time;
 		unsigned long	last_response_time;
 
-		static unsigned long	recv_time_out;
-		static unsigned long	send_time_out;
-
 		std::string				read_buff;
 		std::queue<Request>		requests;
 		std::queue<Response>	responses;

--- a/ConfigParser.cpp
+++ b/ConfigParser.cpp
@@ -465,7 +465,7 @@ int		ConfigParser::putError(const char* err_msg, std::string opt = "") {
 // Public Functions
 //------------------------------------------------------------------------------
 
-ConfigParser::ConfigParser(const char* config_path)
+ConfigParser::ConfigParser(std::string config_path)
 	: server_config(ConfigParser::server_config_arr, ConfigParser::server_config_arr \
 			+ sizeof(ConfigParser::server_config_arr) / sizeof(std::pair<std::string, Directive>)),
 	  location_config(ConfigParser::location_config_arr, ConfigParser::location_config_arr \

--- a/ConfigParser.cpp
+++ b/ConfigParser.cpp
@@ -431,9 +431,9 @@ int	ConfigParser::locationBlock(std::vector<Location>& locations, \
 
 int		ConfigParser::putError(const char* err_msg, std::string opt = "") {
 	std::string	seperator(": ");
-	std::cerr << class_name << seperator << method_name << seperator;
+	std::cerr << class_name + seperator + method_name + seperator;
 	if (opt.length())
-		std::cerr << opt << seperator;
+		std::cerr << opt + seperator;
 	std::cerr << err_msg << std::endl;
 	return ERROR;
 }

--- a/ConfigParser.cpp
+++ b/ConfigParser.cpp
@@ -283,12 +283,13 @@ int	ConfigParser::serverBlock(std::vector<std::pair<Server, std::vector<unsigned
 			// if return directive is duplicated
 			if (return_to.first)
 				return this->putError(NAME_DUP_ERR, "return");
-			if (elements.size() != 3)
+			if (elements.size() != 3 && elements.size() != 2)
 				return this->putError(SEMANTIC_ERR, "return");
 			if (status_code_map.find(elements[1]) == status_code_map.end())
 				return this->putError(SEMANTIC_ERR, "return");
 			return_to.first = status_code_map[elements[1]];
-			return_to.second = elements[2];
+			if (elements.size() == 3)
+				return_to.second = elements[2];
 		}
 	} while (elements.size() > 1);
 	// if the code block is not ending

--- a/ConfigParser.cpp
+++ b/ConfigParser.cpp
@@ -162,7 +162,7 @@ int	ConfigParser::httpBlock(ServerManager& server_manager) {
 				iss >> send_timeout;
 				if (iss.fail())
 					return this->putError(SEMANTIC_ERR, "send_timeout");
-				server_manager.setSendTimeOut(send_timeout);
+				server_manager.setSendTimeOut(send_timeout * 1000);
 				send_timeout_check = true;
 				continue;
 			} else if (line_elements[0].compare("recv_timeout")) {
@@ -172,7 +172,7 @@ int	ConfigParser::httpBlock(ServerManager& server_manager) {
 				iss >> recv_timeout;
 				if (iss.fail())
 					return this->putError(SEMANTIC_ERR, "recv_timeout");
-				server_manager.setRecvTimeOut(send_timeout);
+				server_manager.setRecvTimeOut(recv_timeout * 1000);
 				recv_timeout_check = true;
 				continue;
 			} else if (line_elements.size() > 2) {

--- a/ConfigParser.cpp
+++ b/ConfigParser.cpp
@@ -201,7 +201,8 @@ int	ConfigParser::httpBlock(ServerManager& server_manager) {
 	return ret;
 }
 
-int	ConfigParser::serverBlock(std::vector<std::pair<Server, std::vector<unsigned int> > >& configs) {
+int	ConfigParser::serverBlock( \
+	std::vector<std::pair<Server, std::vector<unsigned int> > >& configs) {
 	this->method_name = "serverBlock";
 
 	std::vector<unsigned long>			ports;

--- a/ConfigParser.cpp
+++ b/ConfigParser.cpp
@@ -225,7 +225,7 @@ int	ConfigParser::serverBlock( \
 			return ERROR;
 
 		// if find something else, assuming it a location block.
-		if (this->server_config.count(elements[0] == 0)) {
+		if (this->server_config.count(elements[0]) == 0) {
 			if (this->locationBlock(locations, elements))
 				return ERROR;
 		} else {

--- a/ConfigParser.cpp
+++ b/ConfigParser.cpp
@@ -322,6 +322,7 @@ int	ConfigParser::locationBlock(std::vector<Location>& locations, \
 	bool								method_allowed_check = false; // to check duplicated directives
 	std::map<std::string, std::string>	cgi_infos;
 	std::pair<stat_type, std::string>	return_to = std::make_pair(NULL, "");
+	bool								has_entity = false;
 
 	// Elements included in one line.
 	do { // while (elements.size() > 1);
@@ -415,13 +416,14 @@ int	ConfigParser::locationBlock(std::vector<Location>& locations, \
 			return_to.first = status_code_map[elements[1]];
 			return_to.second = elements[2];
 		}
+		has_entity = true;
 	} while (elements.size() > 1);
 	// if the code block is not ending
 	if (elements[0].compare("}"))
 		return this->putError(SEMANTIC_ERR);
 	// if there is no root directive or no return directive
-	if (!root.length() || !return_to.first)
-		return this->putError(NO_ENTITY_ERR, "root");
+	if (!has_entity)
+		return this->putError(NO_ENTITY_ERR);
 	locations.push_back(Location(path, root, indexes, auto_index, error_pages, \
 		methods_allowed, cgi_infos, return_to));
 	return OK;

--- a/ConfigParser.cpp
+++ b/ConfigParser.cpp
@@ -32,26 +32,22 @@ int	ConfigParser::getSemanticLine(std::string& line) {
 
 	char	buffer[LINE_BUFF_SIZE];
 
-	while (line.length() == 0) { // skipping semantically blank line
+	line = "";
 
-		// first trial for get a line
-		this->config_file.getline(buffer, LINE_BUFF_SIZE);
-		if (this->config_file.bad())
-			return this->putError(READ_LINE_ERR);
-		line = buffer;
-
+	// skipping semantically blank line
+	while (line.length() == 0) {
 		// get line till the end of line
-		while (this->config_file.fail()) {
+		do {
 			this->config_file.getline(buffer, LINE_BUFF_SIZE);
-			if (config_file.bad())
+			if (this->config_file.bad())
 				return this->putError(READ_LINE_ERR);
 			line += buffer;
-		}
+		} while (this->config_file.fail());
 
 		// Delete comment.
 		size_t sharp_pos = line.find_first_of('#');
 		if (sharp_pos != std::string::npos) {
-			line.resize(sharp_pos - 1);
+			line.resize(sharp_pos);
 		}
 
 		// Trim whitespaces.
@@ -61,57 +57,60 @@ int	ConfigParser::getSemanticLine(std::string& line) {
 }
 
 // Identify whether the line is block start or not.
-int ConfigParser::getIntoBlock(std::string block_name, std::string line = "") {
+int ConfigParser::getIntoBlock(std::string block_name, std::vector<std::string> elements) {
 	this->method_name = "getIntoBlock";
 
-	if (line.length() == 0)
-		if (this->getSemanticLine(line));
+	if (elements.size() == 0)
+		if (this->getLineElements(elements));
 			return ERROR;
 
-	if (line.compare("}"))
-		return BLOCK_END;
+	if (elements.size() > 2)
+		return this->putError(SEMANTIC_ERR);
+
+	if (elements[0].compare("}"))
+		return this->putError(SEMANTIC_ERR);
 
 	// Compare block name and leading part of the line
-	std::string candidate = line.substr(0, block_name.length());
-	if (block_name.compare(candidate))
+	if (block_name.compare(elements[0]))
 		return this->putError(NAME_MATCH_ERR);
 
-	// Check if there is only a opening bracket.
-	line.erase(0, block_name.length());
-	line = trimWhitespace(line);
-	if (line.length() == 0)
-		if (this->getSemanticLine(line));
-			return ERROR;
+	// Check if there is only a opening bracket. If it is not block end, error.
+	if (elements.size() == 1) {
+		getLineElements(elements);
+		if (elements.size() != 1 || elements[0].compare("{"))
+			return this->putError(SEMANTIC_ERR);
+		return OK;
+	}
 
-	// if it is not block end, error.
-	if (line.compare("{"))
+	if (elements[1].compare("{"))
 		return this->putError(SEMANTIC_ERR);
+
 	return OK;
 }
 
 // Get path for location block. '{' can be included in the line or not.
 int	ConfigParser::getPath(std::string& path, \
-	std::vector<std::string>& elements) {
+	std::vector<std::string>& line_elements) {
 	this->method_name = "getPath";
 
-	if (elements.size() < 2 || elements.size() > 3)
+	if (line_elements.size() < 2 || line_elements.size() > 3)
 		return this->putError(SEMANTIC_ERR);
 	// check if the block name is location
-	if (elements[0].compare("location"))
+	if (line_elements[0].compare("location"))
 		return this->putError(SEMANTIC_ERR);
-	path = elements[1];
+	path = line_elements[1];
 	// if it seems like having starting bracket
-	if (elements.size() == 3) {
+	if (line_elements.size() == 3) {
 		// but when it is not starting bracket
-		if (elements[2].compare("{"))
+		if (line_elements[2].compare("{"))
 			return this->putError(SEMANTIC_ERR);
 		return OK;
 	}
-	if (this->getLineElements(elements))
+	if (this->getLineElements(line_elements))
 		return ERROR;
-	if (elements.size() != 1)
+	if (line_elements.size() != 1)
 		return this->putError(SEMANTIC_ERR);
-	if (elements[0].compare("{"))
+	if (line_elements[0].compare("{"))
 		return this->putError(SEMANTIC_ERR);
 	return OK;
 }
@@ -143,44 +142,47 @@ int	ConfigParser::httpBlock(ServerManager& server_manager) {
 	std::set<std::string>		server_name_set;
 	std::vector<std::string>	server_name_vec;
 
-	std::vector<std::string>	elements;
+	std::vector<std::string>	line_elements;
 	unsigned long				send_timeout = 0;
 	bool						send_timeout_check = false;
 	unsigned long				recv_timeout = 0;
 	bool						recv_timeout_check = false;
 	int							ret = 0;
-	std::string					line = "";
 
 	while (!ret)
 	{
-		if (this->getLineElements(elements))
+		if (this->getLineElements(line_elements))
 			return ERROR;
-		if (elements.size() == 2) {
-			if (elements[0].compare("send_timeout")) {
+		if (line_elements.size() == 1) {
+			if (line_elements[0].compare("}"))
+				return this->putError(SEMANTIC_ERR);
+			break;
+		} else if (line_elements.size() == 2) {
+			if (line_elements[0].compare("send_timeout")) {
 				if (send_timeout_check)
-					return putError(NAME_DUP_ERR, "send_timeout");
-				std::istringstream	iss(elements[1]);
+					return this->putError(NAME_DUP_ERR, "send_timeout");
+				std::istringstream	iss(line_elements[1]);
 				iss >> send_timeout;
 				if (iss.fail())
-					return putError(SEMANTIC_ERR, "send_timeout");
+					return this->putError(SEMANTIC_ERR, "send_timeout");
 				server_manager.setSendTimeOut(send_timeout);
 				send_timeout_check = true;
-			} else if (elements[0].compare("recv_timeout")) {
+				continue;
+			} else if (line_elements[0].compare("recv_timeout")) {
 				if (recv_timeout_check)
-					return putError(NAME_DUP_ERR, "recv_timeout");
-				std::istringstream	iss(elements[1]);
+					return this->putError(NAME_DUP_ERR, "recv_timeout");
+				std::istringstream	iss(line_elements[1]);
 				iss >> recv_timeout;
 				if (iss.fail())
-					return putError(SEMANTIC_ERR, "recv_timeout");
+					return this->putError(SEMANTIC_ERR, "recv_timeout");
 				server_manager.setRecvTimeOut(send_timeout);
 				recv_timeout_check = true;
+				continue;
+			} else if (line_elements.size() > 2) {
+				return this->putError(SEMANTIC_ERR);
 			}
 		}
-		for (size_t i = 0; i < elements.size(); ++i)
-			line += elements[i] + " ";
-		if ((ret = getIntoBlock("server", line)))
-			return ret;
-		ret = this->serverBlock(configs);
+		ret = this->serverBlock(configs, line_elements);
 
 		// Check server_name duplication by comparing set and vector.
 		std::string	server_name = configs.back().first.getServerName();
@@ -189,21 +191,25 @@ int	ConfigParser::httpBlock(ServerManager& server_manager) {
 			server_name_vec.push_back(server_name);
 		}
 	}
-	if (configs.size() == 0) {
+
+	if (configs.size() == 0)
 		return this->putError(NO_ENTITY_ERR);
-	} else if (ret == BLOCK_END) {
-		// compare here
-		if (server_name_set.size() != server_name_vec.size())
-			return putError(NAME_DUP_ERR, "server_name");
-		server_manager.initServerManager(configs);
-		return OK;
-	}
-	return ret;
+	if (ret < 0)
+		return ret;
+	// compare duplicated server_name here
+	if (server_name_set.size() != server_name_vec.size())
+		return putError(NAME_DUP_ERR, "server_name");
+	server_manager.initServerManager(configs);
+	return OK;
 }
 
 int	ConfigParser::serverBlock( \
-	std::vector<std::pair<Server, std::vector<unsigned int> > >& configs) {
+	std::vector<std::pair<Server, std::vector<unsigned int> > >& configs, \
+	std::vector<std::string>& line_elements) {
 	this->method_name = "serverBlock";
+
+	if (this->getIntoBlock("server", line_elements))
+		return ERROR;
 
 	std::vector<unsigned long>			ports;
 	unsigned int						port;
@@ -305,11 +311,11 @@ int	ConfigParser::serverBlock( \
 }
 
 int	ConfigParser::locationBlock(std::vector<Location>& locations, \
-	std::vector<std::string>& elements) {
+	std::vector<std::string>& line_elements) {
 	this->method_name = "locationBlock";
 
 	std::string	path;
-	if (this->getPath(path, elements))
+	if (this->getPath(path, line_elements))
 		return ERROR;
 
 	// Arguments for Location constructor.
@@ -325,72 +331,72 @@ int	ConfigParser::locationBlock(std::vector<Location>& locations, \
 	bool								has_entity = false;
 
 	// Elements included in one line.
-	do { // while (elements.size() > 1);
-		if (this->getLineElements(elements))
+	do { // while (line_elements.size() > 1);
+		if (this->getLineElements(line_elements))
 			return ERROR;
-		if ((this->location_config.find(elements[0]) \
+		if ((this->location_config.find(line_elements[0]) \
 			== this->location_config.end()))
 			return this->putError(NAME_MATCH_ERR);
 		// root directive. check directive size and duplication.
-		if (!elements[0].compare("root")) {
-			if (elements.size() != 2)
+		if (!line_elements[0].compare("root")) {
+			if (line_elements.size() != 2)
 				return this->putError(SEMANTIC_ERR, "root");
 			if (root.length())
 				return this->putError(NAME_DUP_ERR, "root");
-			root = elements[1];
+			root = line_elements[1];
 		// error_page directive. check directive number.
-		} else if (!elements[0].compare("error_page")) {
-			if (!(elements.size() % 2))
+		} else if (!line_elements[0].compare("error_page")) {
+			if (!(line_elements.size() % 2))
 				return this->putError(SEMANTIC_ERR, "error_page");
 			// error_page 1 2 3 4 a b c d :config
 			// 0          1 2 3 4 5 6 7 8 :index
-			for (size_t i = 1; i <= elements.size() / 2; ++i) {
+			for (size_t i = 1; i <= line_elements.size() / 2; ++i) {
 				std::map<std::string, stat_type>::iterator error_code
-					= status_code_map.find(elements[i]);
+					= status_code_map.find(line_elements[i]);
 				if (error_code == status_code_map.end())
 					return this->putError(SEMANTIC_ERR, "error_page");
 				// if the code already exists
 				if (error_pages.count((*error_code).second))
 					return this->putError(NAME_DUP_ERR, "error_page");
-				error_pages[(*error_code).second] = elements[i * 2];
+				error_pages[(*error_code).second] = line_elements[i * 2];
 			}
 		// index directive. check directive size.
-		} else if (!elements[0].compare("index")) {
-			if (elements.size() == 1)
+		} else if (!line_elements[0].compare("index")) {
+			if (line_elements.size() == 1)
 				return this->putError(NO_ENTITY_ERR, "index");
-			for (size_t i = 1; i < elements.size(); ++i)
-				indexes.push_back(elements[i]);
+			for (size_t i = 1; i < line_elements.size(); ++i)
+				indexes.push_back(line_elements[i]);
 		// auto_index directive. check duplication, directive size, and value.
-		} else if (!elements[0].compare("auto_index")) {
+		} else if (!line_elements[0].compare("auto_index")) {
 			if (auto_index_check)
 				return this->putError(NAME_DUP_ERR, "auto_index");
-			if (elements.size() != 2)
+			if (line_elements.size() != 2)
 				return this->putError(SEMANTIC_ERR, "auto_index");
-			if (!elements[1].compare("on")) {
+			if (!line_elements[1].compare("on")) {
 				auto_index = true;
-			} else if (!elements[1].compare("off")) {
+			} else if (!line_elements[1].compare("off")) {
 				auto_index = false;
 			} else {
 				return this->putError(SEMANTIC_ERR, "auto_index");
 			}
 			auto_index_check = true;
 		// method_allowed directive. check duplication, directive size, and method names.
-		} else if (!elements[0].compare("method_allowed")) {
+		} else if (!line_elements[0].compare("method_allowed")) {
 			if (method_allowed_check)
 				return this->putError(NAME_DUP_ERR, "method_allowed");
-			if (elements.size() > 4)
+			if (line_elements.size() > 4)
 				return this->putError(SEMANTIC_ERR, "method_allowed");
 			bool	get = false, post = false, del = false;
-			for (size_t i = 1; i < elements.size(); ++i) {
+			for (size_t i = 1; i < line_elements.size(); ++i) {
 				if (get || post || del)
 					return this->putError(NAME_DUP_ERR, "method_allowed");
-				if (!elements[i].compare("GET")) {
+				if (!line_elements[i].compare("GET")) {
 					methods_allowed |= GET;
 					get = true;
-				} else if (!elements[i].compare("POST")) {
+				} else if (!line_elements[i].compare("POST")) {
 					methods_allowed |= POST;
 					post = true;
-				} else if (!elements[i].compare("DELETE")) {
+				} else if (!line_elements[i].compare("DELETE")) {
 					methods_allowed |= DELETE;
 					del = true;
 				} else {
@@ -399,27 +405,27 @@ int	ConfigParser::locationBlock(std::vector<Location>& locations, \
 			}
 			method_allowed_check = true;
 		// cgi_info directive. check directive size, cgi extension duplication.
-		} else if (!elements[0].compare("cgi_info")) {
-			if (elements.size() != 3)
+		} else if (!line_elements[0].compare("cgi_info")) {
+			if (line_elements.size() != 3)
 				return this->putError(SEMANTIC_ERR, "cgi_info");
-			if (cgi_infos.count(elements[1]))
+			if (cgi_infos.count(line_elements[1]))
 				return this->putError(NAME_DUP_ERR, "cgi_info");
-			cgi_infos[elements[1]] = elements[2];
+			cgi_infos[line_elements[1]] = line_elements[2];
 		// return directive. check duplication, directive size, and code check.
 		} else {
 			if (return_to.first)
 				return this->putError(NAME_DUP_ERR, "return");
-			if (elements.size() != 3)
+			if (line_elements.size() != 3)
 				return this->putError(SEMANTIC_ERR, "return");
-			if (!status_code_map.count(elements[1]))
+			if (!status_code_map.count(line_elements[1]))
 				return this->putError(SEMANTIC_ERR, "return");
-			return_to.first = status_code_map[elements[1]];
-			return_to.second = elements[2];
+			return_to.first = status_code_map[line_elements[1]];
+			return_to.second = line_elements[2];
 		}
 		has_entity = true;
-	} while (elements.size() > 1);
+	} while (line_elements.size() > 1);
 	// if the code block is not ending
-	if (elements[0].compare("}"))
+	if (line_elements[0].compare("}"))
 		return this->putError(SEMANTIC_ERR);
 	// if there is no root directive or no return directive
 	if (!has_entity)

--- a/ConfigParser.hpp
+++ b/ConfigParser.hpp
@@ -38,7 +38,7 @@ class ConfigParser {
 		int		getLineElements(std::vector<std::string>& elements);
 
 		int		httpBlock(ServerManager& server_manager);
-		int		serverBlock(std::vector<Server>& server);
+		int		serverBlock(std::vector<std::pair<Server, std::vector<unsigned int> > >& configs);
 		int		locationBlock(std::vector<Location>& location, \
 			std::vector<std::string>& elements);
 
@@ -47,7 +47,8 @@ class ConfigParser {
 	public:
 		ConfigParser(const char* config_path);
 		~ConfigParser();
-		int	setServerManager(ServerManager& server_manager);
+		int	setData(ServerManager& server_manager);
+
 };
 
 std::string	trimWhitespace(std::string str);

--- a/ConfigParser.hpp
+++ b/ConfigParser.hpp
@@ -33,14 +33,16 @@ class ConfigParser {
 		std::string				method_name;
 
 		int		getSemanticLine(std::string& line);
-		int		getIntoBlock(std::string block_name, std::string line = "");
-		int		getPath(std::string& path, std::vector<std::string>& elements);
+		int		getIntoBlock(std::string block_name, \
+			std::vector<std::string> elements = std::vector<std::string>(0));
+		int		getPath(std::string& path, std::vector<std::string>& line_elements);
 		int		getLineElements(std::vector<std::string>& elements);
 
 		int		httpBlock(ServerManager& server_manager);
-		int		serverBlock(std::vector<std::pair<Server, std::vector<unsigned int> > >& configs);
+		int		serverBlock(std::vector<std::pair<Server, std::vector<unsigned int> > >& configs, \
+			std::vector<std::string>& line_elements);
 		int		locationBlock(std::vector<Location>& location, \
-			std::vector<std::string>& elements);
+			std::vector<std::string>& line_elements);
 
 		int		putError(const char* err_msg, std::string opt);
 

--- a/ConfigParser.hpp
+++ b/ConfigParser.hpp
@@ -14,6 +14,19 @@
 
 #define WHITE_SPACES " \v\n\r\t"
 
+enum Directive {
+	kRoot,
+	kIndex,
+	kMethodAllowed,
+	kCgiInfo,
+	kListen,
+	kServerName,
+	kAutoIndex,
+	kErrorPage,
+	kClientBodyLimit,
+	kReturn
+};
+
 // This class can be used twice.
 class ConfigParser {
 	private:
@@ -22,11 +35,11 @@ class ConfigParser {
 		ConfigParser&	operator=(const ConfigParser& ref);
 
 		static bool				is_used; // check for duplicated use.
-		static std::string		server_config_arr[6];
-		static std::string		location_config_arr[7];
-		std::set<std::string>	server_config;
-		std::set<std::string>	location_config;
-		std::ifstream			config_file;
+		static std::pair<std::string, Directive>	server_config_arr[6];
+		static std::pair<std::string, Directive>	location_config_arr[7];
+		std::map<std::string, Directive>	server_config;
+		std::map<std::string, Directive>	location_config;
+		std::ifstream				config_file;
 
 		// variables for error_message;
 		std::string				class_name;

--- a/ConfigParser.hpp
+++ b/ConfigParser.hpp
@@ -60,7 +60,7 @@ class ConfigParser {
 		int		putError(const char* err_msg, std::string opt);
 
 	public:
-		ConfigParser(const char* config_path);
+		ConfigParser(std::string config_path);
 		~ConfigParser();
 		int	setData(ServerManager& server_manager);
 

--- a/ConfigParser.hpp
+++ b/ConfigParser.hpp
@@ -37,7 +37,7 @@ class ConfigParser {
 		int		getPath(std::string& path, std::vector<std::string>& elements);
 		int		getLineElements(std::vector<std::string>& elements);
 
-		int		httpBlock(std::vector<Server>& servers);
+		int		httpBlock(ServerManager& server_manager);
 		int		serverBlock(std::vector<Server>& server);
 		int		locationBlock(std::vector<Location>& location, \
 			std::vector<std::string>& elements);
@@ -47,7 +47,7 @@ class ConfigParser {
 	public:
 		ConfigParser(const char* config_path);
 		~ConfigParser();
-		int	setServers(std::vector<Server>& servers);
+		int	setServerManager(ServerManager& server_manager);
 };
 
 std::string	trimWhitespace(std::string str);

--- a/ErrorMsgHandler.cpp
+++ b/ErrorMsgHandler.cpp
@@ -34,7 +34,8 @@ void	sendError() {
 	err_msg_handler.outError();
 }
 
-void	putError(std::string err_msg) {
+int	putError(std::string err_msg) {
 	ErrorMsgHandler err_msg_handler = ErrorMsgHandler::getInstance();
 	err_msg_handler.addError(err_msg);
+	return ERROR;
 }

--- a/ErrorMsgHandler.cpp
+++ b/ErrorMsgHandler.cpp
@@ -13,10 +13,10 @@ ErrorMsgHandler&	ErrorMsgHandler::getInstance() {
 void	ErrorMsgHandler::outError() {
 	const char* out_string;
 	int			string_len;
-	if (this->error_msgs.length() > IO_BUFF_SIZE) {
-		string_len = IO_BUFF_SIZE;
-		out_string = this->error_msgs.substr(0, IO_BUFF_SIZE).c_str();
-		error_msgs = error_msgs.substr(IO_BUFF_SIZE);
+	if (this->error_msgs.length() > ERROR_BUFF) {
+		string_len = ERROR_BUFF;
+		out_string = this->error_msgs.substr(0, ERROR_BUFF).c_str();
+		error_msgs = error_msgs.substr(ERROR_BUFF);
 	} else {
 		string_len = error_msgs.length();
 		out_string = this->error_msgs.c_str();

--- a/ErrorMsgHandler.hpp
+++ b/ErrorMsgHandler.hpp
@@ -21,11 +21,11 @@ class ErrorMsgHandler
 
 
 	public:
-		friend void				sendError();
-		friend void				putError(std::string err_msg);
+		friend void	sendError();
+		friend int	putError(std::string err_msg);
 };
 
 void	sendError();
-void	putError(std::string err_msg);
+int		putError(std::string err_msg);
 
 #endif

--- a/ErrorMsgHandler.hpp
+++ b/ErrorMsgHandler.hpp
@@ -5,6 +5,8 @@
 #include <sys/socket.h>
 #include <string>
 
+#define ERROR_BUFF 1024
+
 class ErrorMsgHandler
 {
 	private:

--- a/PortManager.cpp
+++ b/PortManager.cpp
@@ -1,6 +1,10 @@
 #include "PortManager.hpp"
 
-PortManager::PortManager(const int port_fd, const std::vector<Server> servers)
-	: port_fd(port_fd), servers(servers) {}
+PortManager::PortManager(const unsigned int port_num, const int port_fd, const std::vector<Server&> servers)
+	: port_num(port_num), port_fd(port_fd), servers(servers) {}
 
 PortManager::~PortManager() {}
+
+unsigned int	PortManager::getPortNum() const {
+	return port_num;
+}

--- a/PortManager.cpp
+++ b/PortManager.cpp
@@ -1,10 +1,21 @@
 #include "PortManager.hpp"
 
-PortManager::PortManager(const unsigned int port_num, const int port_fd, const std::vector<Server&> servers)
-	: port_num(port_num), port_fd(port_fd), servers(servers) {}
+PortManager::PortManager(const PortManager& ref)
+	: port_fd(ref.port_fd), servers(ref.servers) {}
 
 PortManager::~PortManager() {}
 
-unsigned int	PortManager::getPortNum() const {
-	return port_num;
+std::vector<const Server>::iterator PortManager::findServer(std::string& host_name) {
+	for (std::vector<const Server>::iterator serv_it = servers.begin();\
+	serv_it < servers.end(); ++serv_it) {
+		if (host_name == serv_it->getServerName())
+			return serv_it;
+	}
+	return servers.begin();
+}
+
+int	PortManager::passRequest(Re3_iter it) {
+	Request& req = *it->getReqPtr();
+	this->findServer(req.getHeader()["host"])->MakeResponse(it);
+	return OK;
 }

--- a/PortManager.cpp
+++ b/PortManager.cpp
@@ -1,7 +1,7 @@
 #include "PortManager.hpp"
 
 PortManager::PortManager(const PortManager& ref)
-	: port_fd(ref.port_fd), servers(ref.servers) {}
+	: port_num(ref.port_num), port_fd(ref.port_fd), servers(ref.servers) {}
 
 PortManager::~PortManager() {}
 
@@ -14,8 +14,8 @@ std::vector<const Server>::iterator PortManager::findServer(std::string& host_na
 	return servers.begin();
 }
 
-int	PortManager::passRequest(Re3_iter it) {
+int	PortManager::passRequest(Re3Iter it) {
 	Request& req = *it->getReqPtr();
-	this->findServer(req.getHeader()["host"])->MakeResponse(it);
+	this->findServer(req.getHeader()["host"])->makeResponse(it);
 	return OK;
 }

--- a/PortManager.hpp
+++ b/PortManager.hpp
@@ -21,7 +21,7 @@ class PortManager {
 		PortManager(const unsigned int port_num, const int port_fd, const std::vector<Server&> servers);
 		~PortManager();
 
-		int	passRequest(Re3_iter it);
+		int	passRequest(Re3Iter it);
 };
 
 #endif

--- a/PortManager.hpp
+++ b/PortManager.hpp
@@ -7,16 +7,18 @@
 
 class PortManager {
 	private:
+		const unsigned int					port_num;
 		const int							port_fd;
-		const std::vector<Server>			servers;
+		const std::vector<Server&>			servers;
 
 		PortManager();
 		PortManager(const PortManager& ref);
 		PortManager&	operator=(const PortManager& ref);
 
 	public:
-		PortManager(const int port_fd, const std::vector<Server&> servers);
+		PortManager(const unsigned int port_num, const int port_fd, const std::vector<Server&> servers);
 		~PortManager();
+		unsigned int	getPortNum() const;
 };
 
 #endif

--- a/PortManager.hpp
+++ b/PortManager.hpp
@@ -4,6 +4,7 @@
 #include <map>
 #include "Webserv.hpp"
 #include "Server.hpp"
+#include "Re3.hpp"
 
 class PortManager {
 	private:
@@ -15,10 +16,12 @@ class PortManager {
 		PortManager(const PortManager& ref);
 		PortManager&	operator=(const PortManager& ref);
 
+		std::vector<const Server>::iterator		findServer(std::string& host_name);
 	public:
 		PortManager(const unsigned int port_num, const int port_fd, const std::vector<Server&> servers);
 		~PortManager();
-		unsigned int	getPortNum() const;
+
+		int	passRequest(Re3_iter it);
 };
 
 #endif

--- a/PortManager.hpp
+++ b/PortManager.hpp
@@ -15,7 +15,7 @@ class PortManager {
 		PortManager&	operator=(const PortManager& ref);
 
 	public:
-		PortManager(const int port_fd, const std::vector<Server> servers);
+		PortManager(const int port_fd, const std::vector<Server&> servers);
 		~PortManager();
 };
 

--- a/Server.cpp
+++ b/Server.cpp
@@ -268,8 +268,7 @@ std::string Server::fileExtension(std::string resource_path)
 }
 
 Server::Server(const Server &ref)
-	: port(ref.port),
-	  server_name(ref.server_name),
+	: server_name(ref.server_name),
 	  default_root(ref.default_root),
 	  default_error_pages(ref.default_error_pages),
 	  client_body_limit(ref.client_body_limit),
@@ -277,15 +276,13 @@ Server::Server(const Server &ref)
 	  return_to(ref.return_to) {}
 
 Server::Server(
-	unsigned int port,
 	std::string server_name,
 	std::string default_root,
 	std::map<stat_type, std::string> default_error_pages,
 	unsigned long client_body_limit,
 	std::vector<Location> locations,
 	std::pair<stat_type, std::string> return_to)
-	: port(port),
-	  server_name(server_name),
+	: server_name(server_name),
 	  default_root(default_root),
 	  default_error_pages(default_error_pages),
 	  client_body_limit(client_body_limit),

--- a/Server.hpp
+++ b/Server.hpp
@@ -48,6 +48,7 @@ class Server
 		~Server();
 
 		unsigned int	getPortNum() const;
+		std::string&	getServerName() const;
 };
 
 #endif

--- a/Server.hpp
+++ b/Server.hpp
@@ -14,7 +14,6 @@
 class Server
 {
 	private:
-		unsigned int						port;
 		std::string							server_name;
 		std::string							default_root;
 		std::map<stat_type, std::string>	default_error_pages;
@@ -40,7 +39,6 @@ class Server
 	public:
 		Server(const Server &ref);
 		Server(
-			unsigned int port,
 			std::string server_name,
 			std::string default_root,
 			std::map<stat_type, std::string> default_error_pages,

--- a/ServerManager.cpp
+++ b/ServerManager.cpp
@@ -16,7 +16,7 @@ int	ServerManager::makeClient(int port_fd, PortManager& port_manager) {
 
 	if (setsockopt(client_fd, SOL_SOCKET, SO_RCVTIMEO, (char*)&this->recv_timeout, sizeof(unsigned long)) < 0)
 		return putError("setsockopt: recv_timeout set failed");
-	if (setsockopt(client_fd, SOL_SOCKET, SO_SNDTIMEO, (char*)&this->recv_timeout, sizeof(unsigned long)) < 0)
+	if (setsockopt(client_fd, SOL_SOCKET, SO_SNDTIMEO, (char*)&this->send_timeout, sizeof(unsigned long)) < 0)
 		return putError("setsockopt: send_timeout set failed");
 
 	fcntl(client_fd, F_SETFL, O_NONBLOCK);
@@ -57,11 +57,12 @@ ServerManager::~ServerManager() {
 
 // Returns an instance of singleton class, ServerManager.
 ServerManager&	ServerManager::getServerManager() {
-	static ServerManager	instance;
+	static ServerManager	instance = ServerManager();
 	return instance;
 }
 
-int	ServerManager::initServerManager(const std::vector<std::pair<Server, std::vector<unsigned int> > > configs) {
+int	ServerManager::initServerManager( \
+	const std::vector<std::pair<Server, std::vector<unsigned int> > > configs) {
 	if (this->status != INITIATED)
 		return ERROR;
 	this->status = OK;
@@ -84,7 +85,7 @@ int	ServerManager::initServerManager(const std::vector<std::pair<Server, std::ve
 	// Set port fd.
 	int					server_socket;
 	struct sockaddr_in	server_addr;
-	for (std::map<unsigned int, std::vector<Server&> >::iterator it = server_sorter.begin();
+	for (std::map<unsigned int, std::vector<Server&> >::iterator it = server_sorter.begin(); \
 		it != server_sorter.end(); ++it) {
 		if ((server_socket = socket(PF_INET, SOCK_STREAM, 0)) == -1) {
 			putError("socket error\n");

--- a/ServerManager.cpp
+++ b/ServerManager.cpp
@@ -47,9 +47,9 @@ int	ServerManager::callKevent() {
 
 ServerManager::~ServerManager() {
 	for (size_t i = 0; i < this->types.size(); ++i) {
-		if (types[i] == PortFd) {
+		if (types[i] == kPortFd) {
 			delete managers[i];
-		} else if (types[i] == ClientFd) {
+		} else if (types[i] == kClientFd) {
 			delete clients[i];
 		}
 	}
@@ -71,7 +71,7 @@ int	ServerManager::initServerManager( \
 	this->kq = kqueue();
 	EV_SET(&this->event_current, STDERR, EVFILT_WRITE, EV_ADD, 0, 0, NULL); // set stderr kevent.
 	this->event_changes.push_back(this->event_current);
-	this->types[STDERR] = StderrFd;
+	this->types[STDERR] = kStderrFd;
 
 	std::map<unsigned int, std::vector<Server&> >	server_sorter;
 
@@ -112,7 +112,7 @@ int	ServerManager::initServerManager( \
 		fcntl(server_socket, F_SETFL, O_NONBLOCK);
 
 		if (this->types.size() < server_socket)
-			this->types.resize(server_socket, Blank);
+			this->types.resize(server_socket, kBlank);
 		if (this->managers.size() < server_socket)
 			this->managers.resize(server_socket, NULL);
 		this->managers[server_socket] = new PortManager(it->first, server_socket, (*it).second);
@@ -140,11 +140,11 @@ int	ServerManager::processEvent() {
 	for (size_t i = 0; i < num; ++i) {
 		fd = this->event_list[i].ident;
 		switch (this->types[fd]) {
-			case PortFd: {
+			case kPortFd: {
 				// managers[i].callPortManager;
 				break;
 			}
-			case ClientFd: {
+			case kClientFd: {
 				if (event_list[i].filter == EVFILT_READ) {
 					//
 				} else if (event_list[i].filter == EVFILT_WRITE) {
@@ -153,13 +153,13 @@ int	ServerManager::processEvent() {
 				// clients[i].callClient;
 				break;
 			}
-			case ResourceFd: {
+			case kResourceFd: {
 				// resources[i].readContent;
 				// if (resources[i].status() == done)
 				//	resources[i].callServer();
 				break;
 			}
-			case StderrFd: {
+			case kStderrFd: {
 				sendError();
 				break;
 			}

--- a/ServerManager.cpp
+++ b/ServerManager.cpp
@@ -100,8 +100,12 @@ void	ServerManager::setStatus(int status) {
 	this->status = status;
 }
 
-int	ServerManager::getStatus() {
+int		ServerManager::getStatus() {
 	return (this->status);
+}
+
+std::vector<Server>&	ServerManager::getServersRef() {
+	return this->servers;
 }
 
 int	ServerManager::processEvent() {

--- a/ServerManager.cpp
+++ b/ServerManager.cpp
@@ -7,9 +7,9 @@
 ServerManager::ServerManager()
 	: status(INITIATED) {}
 
-int	ServerManager::makeClient(int port_fd, PortManager& port_manager) {
+int	ServerManager::makeClient(PortManager& port_manager) {
 	int	client_fd;
-	if (client_fd = accept(port_fd, NULL, NULL) < 0) {
+	if (client_fd = accept(port_manager.getPortNum(), NULL, NULL) < 0) {
 		putError("accept error");
 		return ERROR;
 	}
@@ -27,10 +27,10 @@ int	ServerManager::makeClient(int port_fd, PortManager& port_manager) {
 	this->event_changes.push_back(event_current);
 
 	if (this->types.size() < client_fd)
-		this->types.resize(client_fd, Blank);
+		this->types.resize(client_fd, kBlank);
 	if (this->clients.size() < client_fd)
 		this->clients.resize(client_fd, NULL);
-	types[client_fd] = ClientFd;
+	types[client_fd] = kClientFd;
 	clients[client_fd] = new Client(client_fd, port_manager);
 	return OK;
 }
@@ -141,7 +141,7 @@ int	ServerManager::processEvent() {
 		fd = this->event_list[i].ident;
 		switch (this->types[fd]) {
 			case kPortFd: {
-				// managers[i].callPortManager;
+				this->makeClient(*this->managers[fd]);
 				break;
 			}
 			case kClientFd: {

--- a/ServerManager.cpp
+++ b/ServerManager.cpp
@@ -115,7 +115,7 @@ int	ServerManager::initServerManager( \
 			this->types.resize(server_socket, Blank);
 		if (this->managers.size() < server_socket)
 			this->managers.resize(server_socket, NULL);
-		this->managers[server_socket] = new PortManager(server_socket, (*it).second);
+		this->managers[server_socket] = new PortManager(it->first, server_socket, (*it).second);
 	}
 }
 

--- a/ServerManager.hpp
+++ b/ServerManager.hpp
@@ -53,7 +53,7 @@ class ServerManager {
 		ServerManager&	operator=(const ServerManager& ref);
 
 		int	callKevent();
-		int	makeClient(int port_fd, PortManager& port_manager);
+		int	makeClient(PortManager& port_manager);
 
 	public:
 		~ServerManager();
@@ -66,75 +66,5 @@ class ServerManager {
 		std::vector<Server>&	getServersRef();
 		int	processEvent();
 };
-
-
-/*
-class	ServerManager
-{
-	vector<type>		types
-
-	vector<Server>		servers
-	vector<Client>		clients
-	vector<Resource>	resources
-
-	unsigned long		send_time_out
-	unsigned long		recv_time_out
-
-	vector<kevent>		change_events
-	kevent				event_list[EVENT_SIZE]
-	kevent				current_event
-	int					type
-
-	acceptClient(int fd)
-	{
-		int client_fd = accept()
-		client(client_fd, servers[fd])
-	}
-
-public
-	parseConfig(std::string config_path)
-	initWebserv()
-	initKqueue()
-	enrollServer()
-	callKevent()
-	reactEvent(int event_num)
-	{
-		current_event = event_list[event_num]
-		type = types[current_event.ident]
-		if (error)
-			deal_with_it
-		if (type == SERVER)
-			acceptClient(fd)
-		else if (type == CLIENT)
-		{
-			if (filter == EVFILT_READ)
-			{
-				clients[fd].readRequest
-
-				status = status_check();
-				if (status == BLANK || status == FINISH)
-
-				read(fd, 1024);
-				parsing();
-				status_mark();
-			}
-			else if (filter == EVFILT_WRITE)
-			{
-				client[fd].writeResponse
-
-				status_check();
-				write(respond);
-			}
-		}
-		else
-		{
-			read resource
-			clients[fd].processResource()
-		}
-	}
-	clientClose()
-
-}
-*/
 
 #endif

--- a/ServerManager.hpp
+++ b/ServerManager.hpp
@@ -47,19 +47,18 @@ class ServerManager {
 		struct kevent				event_list[EVENT_SIZE];
 		struct kevent				event_current;
 
-// Base constructor, copy constructor, and assignation operator are disabled.
 		ServerManager();
+// copy constructor, and assignation operator are disabled.
 		ServerManager(const ServerManager& ref);
 		ServerManager&	operator=(const ServerManager& ref);
-
-		ServerManager(const std::vector<Server> servers);
 
 		int	callKevent();
 		int	makeClient(int port_fd, PortManager& port_manager);
 
 	public:
 		~ServerManager();
-		static ServerManager&	getServerManager(const std::vector<Server> servers);
+		static ServerManager&	getServerManager();
+		int		initServerManager(const std::vector<std::pair<Server, std::vector<unsigned int> > > configs);
 		void	setStatus(int status);
 		void	setSendTimeOut(unsigned long send_time_out);
 		void	setRecvTimeOut(unsigned long recv_time_out);

--- a/ServerManager.hpp
+++ b/ServerManager.hpp
@@ -57,14 +57,14 @@ class ServerManager {
 
 	public:
 		~ServerManager();
+		int						getStatus();
 		static ServerManager&	getServerManager();
-		int		initServerManager(const std::vector<std::pair<Server, std::vector<unsigned int> > > configs);
-		void	setStatus(int status);
-		void	setSendTimeOut(unsigned long send_time_out);
-		void	setRecvTimeOut(unsigned long recv_time_out);
-		int		getStatus();
 		std::vector<Server>&	getServersRef();
-		int	processEvent();
+		void					setStatus(int status);
+		void					setSendTimeOut(unsigned long send_time_out);
+		void					setRecvTimeOut(unsigned long recv_time_out);
+		int						processEvent();
+		int						initServerManager(const std::vector<std::pair<Server, std::vector<unsigned int> > > configs);
 };
 
 #endif

--- a/ServerManager.hpp
+++ b/ServerManager.hpp
@@ -28,6 +28,7 @@
 class ServerManager {
 	private:
 		int							status;
+		std::vector<Server>			servers; // contains original servers.
 
 // Variable types stores the type of fd, which can be connected to a server, a client or a resource.
 // These connection can be reached by variables servers, clients, resources.
@@ -37,8 +38,8 @@ class ServerManager {
 		std::vector<Re3*>			Re3s;
 
 // Send_time_out and recv_time_out is determined by configuration file.
-		unsigned long				send_time_out;
-		unsigned long				recv_time_out;
+		unsigned long				send_timeout;
+		unsigned long				recv_timeout;
 
 // These variables are needed for using kqueue
 		int							kq;
@@ -59,8 +60,11 @@ class ServerManager {
 	public:
 		~ServerManager();
 		static ServerManager&	getServerManager(const std::vector<Server> servers);
-		int	getStatus();
-		void setStatus(int status);
+		void	setStatus(int status);
+		void	setSendTimeOut(unsigned long send_time_out);
+		void	setRecvTimeOut(unsigned long recv_time_out);
+		int		getStatus();
+		std::vector<Server>&	getServersRef();
 		int	processEvent();
 };
 

--- a/Webserv.hpp
+++ b/Webserv.hpp
@@ -10,7 +10,7 @@
 #define STDERR 2
 
 #define BLOCK_END 101
-#define	QUIT 24
+#define	INTR 24
 #define INITIATED 48
 
 #define OPEN_FILE_ERR	"Failed to open file."

--- a/Webserv.hpp
+++ b/Webserv.hpp
@@ -21,7 +21,8 @@
 #define NO_ENTITY_ERR	"There is no entity."
 
 #define LINE_BUFF_SIZE 1024
-#define	IO_BUFF_SIZE 65536
+#define	SEND_RECV_SIZE 16384
+#define LOCAL_IO_SIZE 8192
 #define MAX_CLIENT 5
 
 #define C100 "100 Continue"

--- a/Webserv.hpp
+++ b/Webserv.hpp
@@ -73,6 +73,8 @@ static stat_type	status_code_arr[] = {C100, C101, C200, C201, C202,
 	C401, C402, C403, C404, C405, C406, C407, C408, C409, C410, C411, C412,
 	C413, C414, C415, C416, C417, C500, C501, C502, C503, C504, C505};
 
+#define DEFAULT_ROUTE "default.config"
+
 #include <map>
 #include <string>
 static std::map<std::string, stat_type>	status_code_map;

--- a/Webserv.hpp
+++ b/Webserv.hpp
@@ -80,31 +80,31 @@ static std::map<std::string, stat_type>	status_code_map;
 #define RE3 triplet<Request, Response, Resource>
 
 enum	FdType {
-	Blank,
-	PortFd,
-	ClientFd,
-	ResourceFd,
-	StderrFd
+	kBlank,
+	kPortFd,
+	kClientFd,
+	kResourceFd,
+	kStderrFd
 };
 
 
 enum	Status {
-	Nothing,
-	Header,
-	Body,
-	Finished,
+	kNothing,
+	kHeader,
+	kBody,
+	kFinished,
 };
 
 enum	ReadError {
-	Good,
-	Disconnect,
-	ReadFail,
+	kGood,
+	kDisconnect,
+	kReadFail,
 };
 
 enum	FileType {
-	File,
-	Directory,
-	Notfound
+	kFile,
+	kDirectory,
+	kNotfound
 };
 
 #define GET    0b001

--- a/Webserv.hpp
+++ b/Webserv.hpp
@@ -10,6 +10,7 @@
 
 #define BLOCK_END 101
 #define	QUIT 24
+#define INITIATED 48
 
 #define OPEN_FILE_ERR	"Failed to open file."
 #define READ_LINE_ERR	"Failed to read a line."

--- a/Webserv.hpp
+++ b/Webserv.hpp
@@ -2,6 +2,7 @@
 #define WEBSERV_WEBSERV_HPP_
 
 #include <csignal>
+#include <climits>
 
 #define ERROR -1
 #define OK     0

--- a/main.cpp
+++ b/main.cpp
@@ -10,27 +10,31 @@ void	initStatusCodeMap() {
 }
 
 void	sigIntHandler(int param) {
-	ServerManager& server_manager = ServerManager::getServerManager(std::vector<Server>(0));
-	server_manager.setStatus(ERROR);
+	ServerManager& server_manager = ServerManager::getServerManager();
+	server_manager.setStatus(QUIT);
 };
 
 int	main(int argc, char* argv[]) {
 	initStatusCodeMap();
 
-	std::vector<Server>	servers;
+	ServerManager& server_manager = ServerManager::getServerManager();
 	{
 		ConfigParser	config_parser(argv[1]);
-		config_parser.setServers(servers);
+		config_parser.setData(server_manager);
 	}
 
 	// When CTRL-C is pressed, deallocate everything and end the server.
 	signal(SIGINT, sigIntHandler);
 
-	ServerManager& server_manager = ServerManager::getServerManager(servers);
 	while (true) {
-		if (server_manager.getStatus() == ERROR)
+		if (server_manager.getStatus() != OK)
 			break;
 		server_manager.processEvent();
+	}
+	if (server_manager.getStatus() == ERROR)
+		return ERROR;
+	if (server_manager.getStatus() == QUIT) {
+		// Adequate processing
 	}
 	return OK;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -19,7 +19,16 @@ int	main(int argc, char* argv[]) {
 
 	ServerManager& server_manager = ServerManager::getServerManager();
 	{
-		ConfigParser	config_parser(argv[1]);
+		std::string	config_path;
+		if (argc == 1) {
+			config_path = DEFAULT_ROUTE;
+		} else if (argc == 2) {
+			config_path = argv[1];
+		} else {
+			std::cerr << "Too many arguments.";
+			return ERROR;
+		}
+		ConfigParser	config_parser(config_path);
 		config_parser.setData(server_manager);
 	}
 

--- a/main.cpp
+++ b/main.cpp
@@ -24,7 +24,8 @@ int	main(int argc, char* argv[]) {
 	}
 
 	// When CTRL-C is pressed, deallocate everything and end the server.
-	signal(SIGINT, sigIntHandler);
+	if ((signal(SIGINT, sigIntHandler) == SIG_ERR));
+		return ERROR;
 
 	while (true) {
 		if (server_manager.getStatus() != OK)

--- a/main.cpp
+++ b/main.cpp
@@ -11,7 +11,7 @@ void	initStatusCodeMap() {
 
 void	sigIntHandler(int param) {
 	ServerManager& server_manager = ServerManager::getServerManager();
-	server_manager.setStatus(QUIT);
+	server_manager.setStatus(INTR);
 };
 
 int	main(int argc, char* argv[]) {
@@ -33,7 +33,7 @@ int	main(int argc, char* argv[]) {
 	}
 	if (server_manager.getStatus() == ERROR)
 		return ERROR;
-	if (server_manager.getStatus() == QUIT) {
+	if (server_manager.getStatus() == INTR) {
 		// Adequate processing
 	}
 	return OK;

--- a/pseudocode/our.config
+++ b/pseudocode/our.config
@@ -23,6 +23,8 @@
 
 http
 {
+  send_timeout 200
+  recv_timeout 200
 
   server {
     listen       8080; # port number


### PR DESCRIPTION
close #28. 서버 하나에 port 여러 개일 때의 구조 짜기
자세한 것은 이슈 참조.
ServerManager가 ConfigParser속으로 들어가 초기화하도록 변경.